### PR TITLE
add Expectf helper function to allow for easier string formatting

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -17,9 +17,16 @@ package expect
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"unicode/utf8"
 )
+
+// Expectf reads from the Console's tty until the provided formatted string
+// is read or an error occurs, and returns the buffer read by Console.
+func (c *Console) Expectf(format string, args ...interface{}) (string, error) {
+	return c.Expect(String(fmt.Sprintf(format, args...)))
+}
 
 // ExpectString reads from Console's tty until the provided string is read or
 // an error occurs, and returns the buffer read by Console.

--- a/expect_test.go
+++ b/expect_test.go
@@ -63,6 +63,29 @@ func Prompt(in io.Reader, out io.Writer) error {
 	return nil
 }
 
+func TestExpectf(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewTestConsole(t)
+	if err != nil {
+		t.Errorf("Expected no error but got'%s'", err)
+	}
+	defer c.Close()
+
+	go func() {
+		c.Expectf("What is 1+%d?", 1)
+		c.SendLine("2")
+		c.Expectf("What is %s backwards?", "Netflix")
+		c.SendLine("xilfteN")
+		c.ExpectEOF()
+	}()
+
+	err = Prompt(c.Tty(), c.Tty())
+	if err != nil {
+		t.Errorf("Expected no error but got '%s'", err)
+	}
+}
+
 func TestExpect(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I found myself doing:

```
c.ExpectString(fmt.Sprintf("Expecting %s", str))
```

And thought this would be a common enough pattern to provide a helper function:
```
c.Expectf("Expecting %s", str)
```

