### PR TITLE
Add WithTimeout, WithDefaultTimeout options for Expect and Console.

### DIFF
--- a/expect_opt.go
+++ b/expect_opt.go
@@ -21,10 +21,19 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // ExpectOpt allows settings Expect options.
 type ExpectOpt func(*ExpectOpts) error
+
+// WithTimeout sets a read timeout for an Expect statement.
+func WithTimeout(timeout time.Duration) ExpectOpt {
+	return func(opts *ExpectOpts) error {
+		opts.ReadTimeout = &timeout
+		return nil
+	}
+}
 
 // ConsoleCallback is a callback function to execute if a match is found for
 // the chained matcher.
@@ -52,7 +61,8 @@ func (eo ExpectOpt) Then(f ConsoleCallback) ExpectOpt {
 
 // ExpectOpts provides additional options on Expect.
 type ExpectOpts struct {
-	Matchers []Matcher
+	Matchers    []Matcher
+	ReadTimeout *time.Duration
 }
 
 // Match sequentially calls Match on all matchers in ExpectOpts and returns the

--- a/passthrough_pipe.go
+++ b/passthrough_pipe.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expect
+
+import (
+	"io"
+	"os"
+	"time"
+)
+
+// PassthroughPipe is pipes data from a io.Reader and allows setting a read
+// deadline. If a timeout is reached the error is returned, otherwise the error
+// from the provided io.Reader is returned is passed through instead.
+type PassthroughPipe struct {
+	reader *os.File
+	errC   chan error
+}
+
+// NewPassthroughPipe returns a new pipe for a io.Reader that passes through
+// non-timeout errors.
+func NewPassthroughPipe(reader io.Reader) (*PassthroughPipe, error) {
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	errC := make(chan error, 1)
+	go func() {
+		defer close(errC)
+		_, readerErr := io.Copy(pipeWriter, reader)
+
+		// Closing the pipeWriter will unblock the pipeReader.Read.
+		err = pipeWriter.Close()
+		if err != nil {
+			// If we are unable to close the pipe, and the pipe isn't already closed,
+			// the caller will hang indefinitely.
+			panic(err)
+			return
+		}
+
+		// When an error is read from reader, we need it to passthrough the err to
+		// callers of (*PassthroughPipe).Read.
+		errC <- readerErr
+	}()
+
+	return &PassthroughPipe{
+		reader: pipeReader,
+		errC:   errC,
+	}, nil
+}
+
+func (pp *PassthroughPipe) Read(p []byte) (n int, err error) {
+	n, err = pp.reader.Read(p)
+	if err != nil {
+		if os.IsTimeout(err) {
+			return n, err
+		}
+
+		err = <-pp.errC
+		return n, err
+	}
+
+	return n, nil
+}
+
+func (pp *PassthroughPipe) Close() error {
+	return pp.reader.Close()
+}
+
+func (pp *PassthroughPipe) SetReadDeadline(t time.Time) error {
+	return pp.reader.SetReadDeadline(t)
+}

--- a/passthrough_pipe_test.go
+++ b/passthrough_pipe_test.go
@@ -1,0 +1,46 @@
+package expect
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPassthroughPipe(t *testing.T) {
+	r, w := io.Pipe()
+
+	passthroughPipe, err := NewPassthroughPipe(r)
+	require.NoError(t, err)
+
+	err = passthroughPipe.SetReadDeadline(time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	pipeError := errors.New("pipe error")
+	err = w.CloseWithError(pipeError)
+	require.NoError(t, err)
+
+	p := make([]byte, 1)
+	_, err = passthroughPipe.Read(p)
+	require.Equal(t, err, pipeError)
+}
+
+func TestPassthroughPipeTimeout(t *testing.T) {
+	r, w := io.Pipe()
+
+	passthroughPipe, err := NewPassthroughPipe(r)
+	require.NoError(t, err)
+
+	err = passthroughPipe.SetReadDeadline(time.Now())
+	require.NoError(t, err)
+
+	_, err = w.Write([]byte("gibberish"))
+	require.NoError(t, err)
+
+	p := make([]byte, 1)
+	_, err = passthroughPipe.Read(p)
+	require.True(t, os.IsTimeout(err))
+}


### PR DESCRIPTION
Closes #5 

Introduces `WithTimeout` and `WithDefaultTimeout` for debugging hanging `go-expect` tests.

`PassthroughPipe` is necessary because the `ptm` does not support `SetReadDeadline` so we have to copy data over a `os.Pipe`. But we also want error matchers to continue matching against the original errors outputted by the `ptm` if they are not timeout errors.