### PR TITLE
 Fix OSX io.ErrNoProgress error when using longer Timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
   - "1.10.2"
   - master

--- a/passthrough_pipe_test.go
+++ b/passthrough_pipe_test.go
@@ -37,10 +37,17 @@ func TestPassthroughPipeTimeout(t *testing.T) {
 	err = passthroughPipe.SetReadDeadline(time.Now())
 	require.NoError(t, err)
 
-	_, err = w.Write([]byte("gibberish"))
+	_, err = w.Write([]byte("a"))
 	require.NoError(t, err)
 
 	p := make([]byte, 1)
 	_, err = passthroughPipe.Read(p)
 	require.True(t, os.IsTimeout(err))
+
+	err = passthroughPipe.SetReadDeadline(time.Time{})
+	require.NoError(t, err)
+
+	n, err := passthroughPipe.Read(p)
+	require.Equal(t, 1, n)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
OSX ptm successfully returns nil error for io.Copy, causing Expect read loop to return io.ErrNoProgress. We set it back to io.EOF to surface it back to Expect to exit cleanly.

This PR also enables OSX tests on travis.