### PR TITLE
send all missed expect matchers to the observers when there is an error.

### DIFF
--- a/console.go
+++ b/console.go
@@ -56,10 +56,11 @@ type ConsoleOpts struct {
 
 // ExpectObserver provides an interface for a function callback that will
 // be called after each Expect operation.
-// matcher will be the Matcher that matched the buffer in buf. May be nil.
+// matchers will be the list of active matchers when an error occurred,
+//   or a list of matchers that matched `buf` when err is nil.
 // buf is the captured output that was matched against.
-// err is error that might have occured. May be nil.
-type ExpectObserver func(matcher Matcher, buf string, err error)
+// err is error that might have occurred. May be nil.
+type ExpectObserver func(matchers []Matcher, buf string, err error)
 
 // SendObserver provides an interface for a function callback that will
 // be called after each Send operation.

--- a/expect.go
+++ b/expect.go
@@ -69,7 +69,11 @@ func (c *Console) Expect(opts ...ExpectOpt) (string, error) {
 
 	defer func() {
 		for _, observer := range c.opts.ExpectObservers {
-			observer(matcher, buf.String(), err)
+			if matcher != nil {
+				observer([]Matcher{matcher}, buf.String(), err)
+				return
+			}
+			observer(options.Matchers, buf.String(), err)
 		}
 	}()
 

--- a/expect_test.go
+++ b/expect_test.go
@@ -77,11 +77,18 @@ func newTestConsole(t *testing.T, opts ...ConsoleOpt) (*Console, error) {
 
 func expectNoError(t *testing.T) ConsoleOpt {
 	return WithExpectObserver(
-		func(matcher Matcher, buf string, err error) {
-			if matcher == nil && err != nil {
-				t.Fatalf("Error occured while matching %q: %s\n%s", buf, err, string(debug.Stack()))
-			} else if err != nil {
-				t.Fatalf("Failed to find %v in %q: %s\n%s", matcher.Criteria(), buf, err, string(debug.Stack()))
+		func(matchers []Matcher, buf string, err error) {
+			if err == nil {
+				return
+			}
+			if len(matchers) == 0 {
+				t.Fatalf("Error occurred while matching %q: %s\n%s", buf, err, string(debug.Stack()))
+			} else {
+				var criteria []string
+				for _, matcher := range matchers {
+					criteria = append(criteria, fmt.Sprintf("%q", matcher.Criteria()))
+				}
+				t.Fatalf("Failed to find [%s] in %q: %s\n%s", strings.Join(criteria, ", "), buf, err, string(debug.Stack()))
 			}
 		},
 	)


### PR DESCRIPTION
When there is an error currently the observers will not get the matchers that were attempting to match when we get an error.  The scenario is that we have a mismatch and get an EOF error, at that point we lose the context for what we were attempting to match when we got the EOF.

This change modifies the observer interface to potentially take a list of matchers.  There will be one and only one matcher when there is no error (ie when there is a match) and one+ matchers when there is an error.