### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-expect
 
-[![Build Status](https://travis-ci.org/Netflix/go-expect.svg?branch=master)](https://travis-ci.org/Netflix/go-expect)
+[![Build Status](https://travis-ci.com/Netflix/go-expect.svg?branch=master)](https://travis-ci.com/Netflix/go-expect)
 [![GoDoc](https://godoc.org/github.com/Netflix/go-expect?status.svg)](https://godoc.org/github.com/Netflix/go-expect)
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/go-expect.svg)]()
 


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).