### PR TITLE
fixed file descriptors leakage

### DIFF
--- a/console.go
+++ b/console.go
@@ -155,7 +155,7 @@ func NewConsole(opts ...ConsoleOpt) (*Console, error) {
 	if err != nil {
 		return nil, err
 	}
-	closers = append(options.Closers, passthroughPipe)
+	closers = append(closers, passthroughPipe)
 
 	c := &Console{
 		opts:            options,


### PR DESCRIPTION
not all file descriptors are getting added to closers and hence close function is not closing all FDs.