### PR TITLE
Update example code to use `x/term` instead of `x/crypto/ssh/terminal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ func main() {
 }
 ```
 
-### `golang.org/x/crypto/ssh/terminal` example
+### `golang.org/x/term` example
 
 ```go
 package main
@@ -66,13 +66,13 @@ package main
 import (
 	"fmt"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	expect "github.com/Netflix/go-expect"
 )
 
 func getPassword(fd int) string {
-	bytePassword, _ := terminal.ReadPassword(fd)
+	bytePassword, _ := term.ReadPassword(fd)
 
 	return string(bytePassword)
 }


### PR DESCRIPTION
Because `x/crypto/ssh/terminal` is deprecated and moved to `x/term`.
https://pkg.go.dev/golang.org/x/crypto/ssh/terminal#pkg-overview