### PR TITLE
chore: ioutil.Discard, ioutil.ReadFil and ioutil.TempFile, is deprecated

### DIFF
--- a/console.go
+++ b/console.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -57,7 +56,9 @@ type ConsoleOpts struct {
 // ExpectObserver provides an interface for a function callback that will
 // be called after each Expect operation.
 // matchers will be the list of active matchers when an error occurred,
-//   or a list of matchers that matched `buf` when err is nil.
+//
+//	or a list of matchers that matched `buf` when err is nil.
+//
 // buf is the captured output that was matched against.
 // err is error that might have occurred. May be nil.
 type ExpectObserver func(matchers []Matcher, buf string, err error)
@@ -136,7 +137,7 @@ func WithDefaultTimeout(timeout time.Duration) ConsoleOpt {
 // NewConsole returns a new Console with the given options.
 func NewConsole(opts ...ConsoleOpt) (*Console, error) {
 	options := ConsoleOpts{
-		Logger: log.New(ioutil.Discard, "", 0),
+		Logger: log.New(io.Discard, "", 0),
 	}
 
 	for _, opt := range opts {

--- a/expect_test.go
+++ b/expect_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -336,7 +335,7 @@ func TestEditor(t *testing.T) {
 	}
 	defer testCloser(t, c)
 
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}
@@ -363,7 +362,7 @@ func TestEditor(t *testing.T) {
 	testCloser(t, c.Tty())
 	wg.Wait()
 
-	data, err := ioutil.ReadFile(file.Name())
+	data, err := os.ReadFile(file.Name())
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
 	}


### PR DESCRIPTION
```
// Deprecated: As of Go 1.16, this value is simply [io.Discard].
var Discard io.Writer = io.Discard

// Deprecated: As of Go 1.17, this function simply calls [os.CreateTemp].
func TempFile(dir, pattern string) (f *os.File, err error) {

// Deprecated: As of Go 1.16, this function simply calls [os.ReadFile].
func ReadFile(filename string) ([]byte, error) {
```
